### PR TITLE
Use DLVersion to represent versions, not strings.

### DIFF
--- a/DLRAppStoreRatings.podspec
+++ b/DLRAppStoreRatings.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.public_header_files = 'DLRAppStoreRatings/source/**/*.h'
 
   s.dependency 'DLRUIKit', '~> 1.2'
+  s.dependency 'DLVersion', '~> 0.3'
 end

--- a/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.h
+++ b/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.h
@@ -8,9 +8,9 @@
 
 #import <Foundation/Foundation.h>
 
-#import "DLVersion.h"
-
 NS_ASSUME_NONNULL_BEGIN
+
+@class DLVersion;
 
 @interface DLRAppStoreRatingsDataSource : NSObject
 

--- a/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.h
+++ b/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.h
@@ -8,15 +8,17 @@
 
 #import <Foundation/Foundation.h>
 
+#import "DLVersion.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface DLRAppStoreRatingsDataSource : NSObject
 
-@property (nullable, nonatomic, copy) NSString *previousKnownVersion;
-@property (nullable, nonatomic, copy) NSDate *lastActionTakenDate;
-@property (nullable, nonatomic, copy) NSString *lastRatedVersion;
-@property (nullable, nonatomic, copy) NSString *lastDeclinedVersion;
-@property (nullable, nonatomic, copy) NSString *lastVersionWithFeedback;
+@property (nullable, nonatomic) DLVersion *previousKnownVersion;
+@property (nullable, nonatomic) NSDate *lastActionTakenDate;
+@property (nullable, nonatomic) DLVersion *lastRatedVersion;
+@property (nullable, nonatomic) DLVersion *lastDeclinedVersion;
+@property (nullable, nonatomic) DLVersion *lastVersionWithFeedback;
 @property (nonatomic, copy) NSDictionary <NSString *, NSNumber *> *events;
 
 + (instancetype)sharedInstance;

--- a/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.m
+++ b/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.m
@@ -30,13 +30,20 @@ static NSString* const kAppRatingsEvents = @"DLR_AppRatings_Events";
 
 #pragma mark - previousKnownVersion property
 
-- (void)setPreviousKnownVersion:(NSString *)previousKnownVersion {
-    [[NSUserDefaults standardUserDefaults] setObject:previousKnownVersion forKey:kAppRatingsCurrentVersion];
+- (void)setPreviousKnownVersion:(DLVersion *)previousKnownVersion {
+    [[NSUserDefaults standardUserDefaults] setObject:previousKnownVersion.string forKey:kAppRatingsCurrentVersion];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (NSString *)previousKnownVersion {
-    return [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsCurrentVersion];
+- (DLVersion *)previousKnownVersion {
+    NSString *version = [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsCurrentVersion];
+    
+    if (version != nil) {
+        return [DLVersion versionWithString:version];
+    }
+    else {
+        return nil;
+    }
 }
 
 #pragma mark - lastActionTakenDate property
@@ -52,35 +59,56 @@ static NSString* const kAppRatingsEvents = @"DLR_AppRatings_Events";
 
 #pragma mark - lastRatedVersion property
 
-- (void)setLastRatedVersion:(NSString *)lastRatedVersion {
-    [[NSUserDefaults standardUserDefaults] setObject:lastRatedVersion forKey:kAppRatingsLastRatedVersion];
+- (void)setLastRatedVersion:(DLVersion *)lastRatedVersion {
+    [[NSUserDefaults standardUserDefaults] setObject:lastRatedVersion.string forKey:kAppRatingsLastRatedVersion];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (NSString *)lastRatedVersion {
-    return [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsLastRatedVersion];
+- (DLVersion *)lastRatedVersion {
+    NSString *version = [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsLastRatedVersion];
+    
+    if (version != nil) {
+        return [DLVersion versionWithString:version];
+    }
+    else {
+        return nil;
+    }
 }
 
 #pragma mark - lastDeclinedVersion property
 
-- (void)setLastDeclinedVersion:(NSString *)lastDeclinedVersion {
-    [[NSUserDefaults standardUserDefaults] setObject:lastDeclinedVersion forKey:kAppRatingsLastDeclinedVersion];
+- (void)setLastDeclinedVersion:(DLVersion *)lastDeclinedVersion {
+    [[NSUserDefaults standardUserDefaults] setObject:lastDeclinedVersion.string forKey:kAppRatingsLastDeclinedVersion];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (NSString *)lastDeclinedVersion {
-    return [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsLastDeclinedVersion];
+- (DLVersion *)lastDeclinedVersion {
+    NSString *version = [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsLastDeclinedVersion];
+    
+    if (version != nil) {
+        return [DLVersion versionWithString:version];
+    }
+    else {
+        return nil;
+    }
 }
 
 #pragma mark - lastVersionWithFeedback property
 
-- (void)setLastVersionWithFeedback:(NSString *)lastVersionWithFeedback {
-    [[NSUserDefaults standardUserDefaults] setObject:lastVersionWithFeedback forKey:kAppRatingsLastVersionWithFeedback];
+- (void)setLastVersionWithFeedback:(DLVersion *)lastVersionWithFeedback {
+    [[NSUserDefaults standardUserDefaults] setObject:lastVersionWithFeedback.string forKey:kAppRatingsLastVersionWithFeedback];
     [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
-- (NSString *)lastVersionWithFeedback {
-    return [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsLastVersionWithFeedback];
+- (DLVersion *)lastVersionWithFeedback {
+    NSString *version = [[NSUserDefaults standardUserDefaults] objectForKey:kAppRatingsLastVersionWithFeedback];
+    
+    if (version != nil) {
+        return [DLVersion versionWithString:version];
+    }
+    else {
+        return nil;
+    }
 }
 
 #pragma mark - events property

--- a/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.m
+++ b/DLRAppStoreRatings/source/DLRAppStoreRatingsDataSource.m
@@ -8,6 +8,8 @@
 
 #import "DLRAppStoreRatingsDataSource.h"
 
+#import "DLVersion.h"
+
 static NSString* const kAppRatingsCurrentVersion = @"DLR_AppRatings_CurrentVersion";
 static NSString* const kAppRatingsLastActionTakeDate = @"DLR_AppRatings_LastActionTaken";
 static NSString* const kAppRatingsLastRatedVersion = @"DLR_AppRatings_LastRatedVersion";

--- a/DLRAppStoreRatings/source/DLRAppStoreRatingsTracker.m
+++ b/DLRAppStoreRatings/source/DLRAppStoreRatingsTracker.m
@@ -14,11 +14,13 @@
 #import "DLRAppStoreRatingsTracker.h"
 #import "UIDevice+DLR.h"
 
+#import "DLVersion.h"
+
 static NSString* const kAppRatingsBundleVersion = @"CFBundleShortVersionString";
 
 @interface DLRAppStoreRatingsTracker()
 
-@property (nonatomic, readonly) NSString *currentAppVersion;
+@property (nonatomic, readonly) DLVersion *currentAppVersion;
 
 @property (nonatomic) NSMutableArray *rules;
 @property (nonatomic) DLRAppStoreRatingsDataSource *dataSource;
@@ -48,7 +50,7 @@ static NSString* const kAppRatingsBundleVersion = @"CFBundleShortVersionString";
         self.shouldPromptForDeclinedVersions = YES;
         self.shouldPromptForVersionsWithFeedback = YES;
         
-        if(![self.dataSource.previousKnownVersion isEqualToString:self.currentAppVersion]) {
+        if(![self.dataSource.previousKnownVersion isEqualToVersion:self.currentAppVersion]) {
             
             [self clearEvents];
             self.dataSource.previousKnownVersion = self.currentAppVersion;
@@ -99,20 +101,20 @@ static NSString* const kAppRatingsBundleVersion = @"CFBundleShortVersionString";
         return YES;
     }
     
-    NSString *currentAppVersion = self.currentAppVersion;
+    DLVersion *currentAppVersion = self.currentAppVersion;
     DLRAppStoreRatingsDataSource *dataSource = self.dataSource;
     
-    if ([currentAppVersion isEqualToString:dataSource.lastRatedVersion]) {
+    if ([currentAppVersion isEqualToVersion:dataSource.lastRatedVersion]) {
         return NO;
     }
     
     if (self.shouldPromptForDeclinedVersions == NO &&
-        [currentAppVersion isEqualToString:dataSource.lastDeclinedVersion]) {
+        [currentAppVersion isEqualToVersion:dataSource.lastDeclinedVersion]) {
         return NO;
     }
     
     if (self.shouldPromptForVersionsWithFeedback == NO &&
-        [currentAppVersion isEqualToString:dataSource.lastVersionWithFeedback]) {
+        [currentAppVersion isEqualToVersion:dataSource.lastVersionWithFeedback]) {
         return NO;
     }
     
@@ -212,8 +214,15 @@ static NSString* const kAppRatingsBundleVersion = @"CFBundleShortVersionString";
     [self updateLastActionTakenDate];
 }
 
-- (NSString *)currentAppVersion {
-    return [[[NSBundle mainBundle] infoDictionary] objectForKey:kAppRatingsBundleVersion];
+- (DLVersion *)currentAppVersion {
+    NSString *versionString = [[[NSBundle mainBundle] infoDictionary] objectForKey:kAppRatingsBundleVersion];
+    
+    if (versionString != nil) {
+        return [DLVersion versionWithString:versionString];
+    }
+    else {
+        return nil;
+    }
 }
 
 - (void)updateLastActionTakenDate {

--- a/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsDataSourceSpec.m
+++ b/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsDataSourceSpec.m
@@ -68,61 +68,61 @@ NSDate *now;
 
 - (void)test_lastRatedVersion_getsTheLastVersionRatedFromStorage {
     
-    NSString *version = @"3.0.0";
+    DLVersion *version = [DLVersion versionWithString:@"3.0.0"];
     
-    OCMStub([userDefaultsMock objectForKey:kAppRatingsLastRatedVersion]).andReturn(version);
+    OCMStub([userDefaultsMock objectForKey:kAppRatingsLastRatedVersion]).andReturn(version.string);
     
-    XCTAssertEqual(dataSource.lastRatedVersion, version, @"Expected lastVersionRated to be equal to given version");
+    XCTAssertEqualObjects(dataSource.lastRatedVersion, version, @"Expected lastVersionRated to be equal to given version");
     
 }
 
 - (void)test_whenUpdatingLastRatedVersion_itStoresTheLastVersionRated {
     
-    NSString *version = @"3.0.0";
+    DLVersion *version = [DLVersion versionWithString:@"3.0.0"];
     
     dataSource.lastRatedVersion = version;
     
-    OCMVerify([userDefaultsMock setObject:version forKey:kAppRatingsLastRatedVersion]);
+    OCMVerify([userDefaultsMock setObject:version.string forKey:kAppRatingsLastRatedVersion]);
     
 }
 
 - (void)test_lastDeclinedVersion_getsTheLastVersionDeclinedFromStorage {
     
-    NSString *version = @"3.0.0";
+    DLVersion *version = [DLVersion versionWithString:@"3.0.0"];
     
-    OCMStub([userDefaultsMock objectForKey:kAppRatingsLastDeclinedVersion]).andReturn(version);
+    OCMStub([userDefaultsMock objectForKey:kAppRatingsLastDeclinedVersion]).andReturn(version.string);
     
-    XCTAssertEqual(dataSource.lastDeclinedVersion, version, @"Expected lastVersionDeclined to be equal to given version");
+    XCTAssertEqualObjects(dataSource.lastDeclinedVersion, version, @"Expected lastVersionDeclined to be equal to given version");
     
 }
 
 - (void)test_whenUpdatingLastDeclinedVersion_itStoresTheLastVersionDeclined {
     
-    NSString *version = @"3.0.0";
+    DLVersion *version = [DLVersion versionWithString:@"3.0.0"];
     
     dataSource.lastDeclinedVersion = version;
     
-    OCMVerify([userDefaultsMock setObject:version forKey:kAppRatingsLastDeclinedVersion]);
+    OCMVerify([userDefaultsMock setObject:version.string forKey:kAppRatingsLastDeclinedVersion]);
     
 }
 
 - (void)test_lastVersionWithFeedback_getsTheLastVersionWithFeedbackFromStorage {
     
-    NSString *version = @"3.0.0";
+    DLVersion *version = [DLVersion versionWithString:@"3.0.0"];
     
-    OCMStub([userDefaultsMock objectForKey:kAppRatingsLastVersionWithFeedback]).andReturn(version);
+    OCMStub([userDefaultsMock objectForKey:kAppRatingsLastVersionWithFeedback]).andReturn(version.string);
     
-    XCTAssertEqual(dataSource.lastVersionWithFeedback, version, @"Expected lastVersionWithFeedback to be equal to given version");
+    XCTAssertEqualObjects(dataSource.lastVersionWithFeedback, version, @"Expected lastVersionWithFeedback to be equal to given version");
     
 }
 
 - (void)test_whenUpdatingLastVersionWithFeedback_itStoresTheLastVersionWithFeedback {
     
-    NSString *version = @"3.0.0";
+    DLVersion *version = [DLVersion versionWithString:@"3.0.0"];
     
     dataSource.lastVersionWithFeedback = version;
     
-    OCMVerify([userDefaultsMock setObject:version forKey:kAppRatingsLastVersionWithFeedback]);
+    OCMVerify([userDefaultsMock setObject:version.string forKey:kAppRatingsLastVersionWithFeedback]);
     
 }
 

--- a/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsDataSourceSpec.m
+++ b/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsDataSourceSpec.m
@@ -12,6 +12,8 @@
 
 #import "DLRAppStoreRatingsDataSource.h"
 
+#import "DLVersion.h"
+
 static NSString* const kAppRatingsEvents = @"DLR_AppRatings_Events";
 static NSString* const kAppRatingsLastActionTakeDate = @"DLR_AppRatings_LastActionTaken";
 static NSString* const kAppRatingsLastRatedVersion = @"DLR_AppRatings_LastRatedVersion";

--- a/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsTrackerSpec.m
+++ b/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsTrackerSpec.m
@@ -50,16 +50,16 @@ id debugManagerMock;
 id sharedApplication;
 
 DLRAppStoreRatingsTracker *tracker;
-NSString *version;
+DLVersion *version;
 
 
 - (void)setUp {
     [super setUp];
     
-    version = @"3.1.1";
+    version = [DLVersion versionWithString:@"3.1.1"];
     
     bundleMock = OCMClassMock([NSBundle class]);
-    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: version};
+    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: version.string};
     OCMStub([bundleMock infoDictionary]).andReturn(infoDictionary);
     OCMStub(ClassMethod([bundleMock mainBundle])).andReturn(bundleMock);
     
@@ -353,7 +353,7 @@ NSString *version;
         return YES;
     }];
     rule.screenName = @"Test Screen";
-    tracker.dataSource.lastRatedVersion = @"3.0.0";
+    tracker.dataSource.lastRatedVersion = [DLVersion versionWithString:@"3.0.0"];
     [tracker addRule:rule];
     
     XCTAssertTrue([tracker shouldTriggerForScreen:@"Test Screen"], @"Expected shouldTrigger to be TRUE");
@@ -446,7 +446,8 @@ NSString *version;
     OCMStub([bundleMock infoDictionary]).andReturn(infoDictionary);
     OCMStub(ClassMethod([bundleMock mainBundle])).andReturn(bundleMock);
     
-    OCMStub([dataSourceMock previousKnownVersion]).andReturn(@"3.0.0");
+    DLVersion *previousVersion = [DLVersion versionWithString:@"3.0.0"];
+    OCMStub([dataSourceMock previousKnownVersion]).andReturn(previousVersion);
     
     tracker = [DLRAppStoreRatingsTracker new];
     
@@ -457,19 +458,21 @@ NSString *version;
 - (void)test_givenAppVersionIsUpdated_whenTrackerIsInitialized_itTellsDataSourceToStoreUpdatedAppVersion {
     
     // already have a tracker at version 3.1.1
+    DLVersion *newVersion = [DLVersion versionWithString:@"4.0.0"];
     
     // stub out bundle so that the new version is higher than the old version
     // recreate bundle mock so we can stub out the same key with a different value
     bundleMock = OCMClassMock([NSBundle class]);
-    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: @"4.0.0"};
+    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: newVersion.string};
     OCMStub([bundleMock infoDictionary]).andReturn(infoDictionary);
     OCMStub(ClassMethod([bundleMock mainBundle])).andReturn(bundleMock);
     
-    OCMStub([dataSourceMock previousKnownVersion]).andReturn(@"3.0.0");
+    DLVersion *previousVersion = [DLVersion versionWithString:@"3.0.0"];
+    OCMStub([dataSourceMock previousKnownVersion]).andReturn(previousVersion);
     
     tracker = [DLRAppStoreRatingsTracker new];
     
-    OCMVerify([dataSourceMock setPreviousKnownVersion:@"4.0.0"]);
+    OCMVerify([dataSourceMock setPreviousKnownVersion:newVersion]);
     
 }
 
@@ -489,17 +492,20 @@ NSString *version;
 
 - (void)test_whenUserSaysNoToRatingOrFeedback_itSetsTheLastDeclinedVersionOfTheApp {
     // already have a tracker at version 3.1.1
+    DLVersion *newVersion = [DLVersion versionWithString:@"4.0.0"];
     
     // stub out bundle so that the new version is higher than the old version
     // recreate bundle mock so we can stub out the same key with a different value
     bundleMock = OCMClassMock([NSBundle class]);
-    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: @"4.0.0"};
+    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: newVersion.string};
     OCMStub([bundleMock infoDictionary]).andReturn(infoDictionary);
     OCMStub(ClassMethod([bundleMock mainBundle])).andReturn(bundleMock);
     
+    [[dataSourceMock expect] setLastVersionWithFeedback:[OCMArg isEqual:newVersion]];
+    
     [tracker userDidDecline];
     
-    OCMVerify([dataSourceMock setLastDeclinedVersion:@"4.0.0"]);
+    OCMVerify(dataSourceMock);
 }
 
 - (void)test_whenUserGivesFeedback_itSetsTheLastActionTakenDateToToday {
@@ -518,17 +524,20 @@ NSString *version;
 
 - (void)test_whenUserGivesFeedback_itSetsTheLastVersionWithFeedbackOfTheApp {
     // already have a tracker at version 3.1.1
+    DLVersion *newVersion = [DLVersion versionWithString:@"4.0.0"];
     
     // stub out bundle so that the new version is higher than the old version
     // recreate bundle mock so we can stub out the same key with a different value
     bundleMock = OCMClassMock([NSBundle class]);
-    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: @"4.0.0"};
+    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: newVersion.string};
     OCMStub([bundleMock infoDictionary]).andReturn(infoDictionary);
     OCMStub(ClassMethod([bundleMock mainBundle])).andReturn(bundleMock);
     
+    [[dataSourceMock expect] setLastVersionWithFeedback:[OCMArg isEqual:newVersion]];
+    
     [tracker userDidSelectFeedback];
     
-    OCMVerify([dataSourceMock setLastVersionWithFeedback:@"4.0.0"]);
+    OCMVerify(dataSourceMock);
 }
 
 - (void)test_whenUserRatesApp_itSetsTheLastActionTakenDateToToday {
@@ -548,17 +557,20 @@ NSString *version;
 - (void)test_whenUserRatesApp_itSetsTheLastRatedVersionOfTheApp {
     
     // already have a tracker at version 3.1.1
+    DLVersion *newVersion = [DLVersion versionWithString:@"4.0.0"];
     
     // stub out bundle so that the new version is higher than the old version
     // recreate bundle mock so we can stub out the same key with a different value
     bundleMock = OCMClassMock([NSBundle class]);
-    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: @"4.0.0"};
+    NSDictionary *infoDictionary = @{kAppRatingsBundleVersion: newVersion.string};
     OCMStub([bundleMock infoDictionary]).andReturn(infoDictionary);
     OCMStub(ClassMethod([bundleMock mainBundle])).andReturn(bundleMock);
     
+    [[dataSourceMock expect] setLastVersionWithFeedback:[OCMArg isEqual:newVersion]];
+    
     [tracker userDidSelectRateApp];
     
-    OCMVerify([dataSourceMock setLastRatedVersion:@"4.0.0"]);
+    OCMVerify(dataSourceMock);
     
 }
 
@@ -625,7 +637,7 @@ NSString *version;
     
     OCMStub([debugManagerMock shouldClearData]).andReturn(YES);
     
-    tracker.dataSource.lastRatedVersion = @"4.0.0";
+    tracker.dataSource.lastRatedVersion = [DLVersion versionWithString:@"4.0.0"];
     
     [tracker addEvent:eventName];
     

--- a/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsTrackerSpec.m
+++ b/DLRAppStoreRatingsTests/source/DLRAppStoreRatingsTrackerSpec.m
@@ -15,6 +15,8 @@
 #import "DLRAppStoreRatingsTracker.h"
 #import "DLRAppStoreRatingsRule.h"
 
+#import "DLVersion.h"
+
 static NSString* const kAppRatingsBundleVersion = @"CFBundleShortVersionString";
 
 id dataSourceMock;

--- a/Podfile
+++ b/Podfile
@@ -2,8 +2,9 @@ platform :ios, '7.0'
 
 target 'DLRAppStoreRatings' do
   pod 'DLRUIKit', '~> 1.2'
+  pod 'DLVersion', '~> 0.3'
 end
 
 target 'DLRAppStoreRatingsTests', :exclusive => true do
-  pod 'OCMock', '~> 3.1'
+  pod 'OCMock', '~> 3.2'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,16 @@
 PODS:
-  - DLRUIKit (1.2.0)
-  - OCMock (3.1.2)
+  - DLRUIKit (1.4.0)
+  - DLVersion (0.3.2)
+  - OCMock (3.2)
 
 DEPENDENCIES:
   - DLRUIKit (~> 1.2)
-  - OCMock (~> 3.1)
+  - DLVersion (~> 0.3)
+  - OCMock (~> 3.2)
 
 SPEC CHECKSUMS:
-  DLRUIKit: 4d3821f03d41b00e05b8aff4c959c297662e9760
-  OCMock: a10ea9f0a6e921651f96f78b6faee95ebc813b92
+  DLRUIKit: a4b109364ee8682d53d487b0d6afa34607251e50
+  DLVersion: 1419cc201fb6e405c12f9c9c47755e4255f8cd7a
+  OCMock: 28def049ef47f996b515a8eeea958be7ccab2dbb
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
Right now, this PR doesn’t add any new functionality, but using DLVersion instead of NSString to represent version numbers could open the door to future functionality that relies on versions (e.g. don’t prompt again until a major release).
